### PR TITLE
Make the links much shorter

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Gray Paper Viewer</title>
+    <title>Gray Paper Reader</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,7 +14,7 @@ import grayPaperMetadata from "../public/metadata.json";
 import { Banner } from "./components/Banner/Banner";
 import { Notes } from "./components/Notes/Notes";
 import { ThemeToggler } from "./components/ThemeToggler/ThemeToggler";
-import { Metadata, Version } from "./components/Version/Version";
+import { type Metadata, Version } from "./components/Version/Version";
 import { getLatestVersion } from "./components/Version/util";
 import { deserializeLocation } from "./utils/location";
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,7 +14,7 @@ import grayPaperMetadata from "../public/metadata.json";
 import { Banner } from "./components/Banner/Banner";
 import { Notes } from "./components/Notes/Notes";
 import { ThemeToggler } from "./components/ThemeToggler/ThemeToggler";
-import { Version } from "./components/Version/Version";
+import { Metadata, Version } from "./components/Version/Version";
 import { getLatestVersion } from "./components/Version/util";
 import { deserializeLocation } from "./utils/location";
 
@@ -85,13 +85,15 @@ function Viewer({ iframeCtrl, selectedVersion, onVersionChange }: ViewerProps) {
   // react to changes in hash location
   useEffect(() => {
     const listener = (ev: HashChangeEvent) => {
-      const [, versionToSelect] = iframeCtrl.goToLocation(`#${ev.newURL.split("#")[1]}`);
+      const [, shortVersion] = iframeCtrl.goToLocation(`#${ev.newURL.split("#")[1]}`);
+      const versionToSelect = findVersion(shortVersion, grayPaperMetadata);
       if (versionToSelect) {
         onVersionChange(versionToSelect);
       }
     };
     // read current hash
-    const [cleanup, versionToSelect] = iframeCtrl.goToLocation(window.location.hash);
+    const [cleanup, shortVersion] = iframeCtrl.goToLocation(window.location.hash);
+    const versionToSelect = findVersion(shortVersion, grayPaperMetadata);
     if (versionToSelect) {
       onVersionChange(versionToSelect);
     }
@@ -154,9 +156,18 @@ function tabsContent(
 
 function getInitialVersion(): string {
   const loc = deserializeLocation(window.location.hash);
-  if (loc) {
-    return loc.version;
+  const version = findVersion(loc?.shortVersion ?? null, grayPaperMetadata);
+  if (version) {
+    return version;
   }
 
   return getLatestVersion(grayPaperMetadata);
+}
+
+function findVersion(shortVersion: string | null, metadata: Metadata) {
+  if (!shortVersion) {
+    return null;
+  }
+
+  return Object.keys(metadata.versions).find((v) => v.startsWith(shortVersion)) ?? null;
 }

--- a/src/utils/IframeController.tsx
+++ b/src/utils/IframeController.tsx
@@ -109,7 +109,7 @@ export class IframeController {
       return [null, null];
     }
 
-    const DIV_PATTERN='<div class="';
+    const DIV_PATTERN = '<div class="';
 
     const classes = loc.selection
       .filter((x) => x.startsWith(DIV_PATTERN))
@@ -122,7 +122,7 @@ export class IframeController {
 
     const $page = this.doc.querySelector(`div[data-page-no="${loc.page}"] > .pc`);
 
-    let $divs;
+    let $divs: (Element | null | undefined)[];
     try {
       $divs = classes.map((c) => $page?.querySelector(`div.${c}`)).filter((x) => x !== null);
       if (!$divs.length) {

--- a/src/utils/IframeController.tsx
+++ b/src/utils/IframeController.tsx
@@ -109,22 +109,31 @@ export class IframeController {
       return [null, null];
     }
 
+    const DIV_PATTERN='<div class="';
+
     const classes = loc.selection
-      .filter((x) => x.startsWith("<div "))
+      .filter((x) => x.startsWith(DIV_PATTERN))
       .map((x) =>
         x
-          .substring('<div class="'.length, x.indexOf(">") - 1)
+          .substring(DIV_PATTERN.length, x.indexOf(">") - 1)
           .split(" ")
           .join("."),
       );
 
     const $page = this.doc.querySelector(`div[data-page-no="${loc.page}"] > .pc`);
 
-    const $divs = classes.map((c) => $page?.querySelector(`div.${c}`)).filter((x) => x !== null);
-    if (!$divs.length) {
-      console.warn("Did not find any divs:", $divs, classes, $page);
-      return [null, loc.version];
+    let $divs;
+    try {
+      $divs = classes.map((c) => $page?.querySelector(`div.${c}`)).filter((x) => x !== null);
+      if (!$divs.length) {
+        console.warn("Did not find any divs:", $divs, classes, $page);
+        return [null, loc.shortVersion];
+      }
+    } catch (e) {
+      console.warn("Invalid querySelector created", e);
+      return [null, loc.shortVersion];
     }
+
     const range = this.doc.createRange();
     const $first = $divs[0];
     const $last = $divs[$divs.length - 1];
@@ -159,10 +168,10 @@ export class IframeController {
         scrollTo("center", "instant");
       }, 300);
 
-      return [() => clearTimeout(timeout), loc.version];
+      return [() => clearTimeout(timeout), loc.shortVersion];
     }
 
-    return [null, loc.version];
+    return [null, loc.shortVersion];
   }
 
   jumpTo(id: string) {

--- a/src/utils/location.ts
+++ b/src/utils/location.ts
@@ -1,7 +1,7 @@
 import type { InDocSelection } from "./IframeController";
 
 export type LocationDetails = {
-  version: string;
+  shortVersion: string;
   page: string;
   section: string;
   subSection: string;
@@ -14,20 +14,29 @@ export function updateLocationVersion(version: string, hash: string): string | n
     return null;
   }
 
-  loc.version = version;
+  loc.shortVersion = version.substring(0, 10);
   return reserializeLocation(loc);
 }
 
 export function reserializeLocation(loc: LocationDetails) {
-  const l = JSON.stringify([loc.version, loc.page, loc.section, loc.subSection, loc.selection]);
+  const l = JSON.stringify([
+    loc.shortVersion,
+    loc.page,
+    loc.section,
+    loc.subSection,
+    loc.selection
+  ]);
 
   return btoa(unescape(encodeURIComponent(l)));
 }
 
 export function serializeLocation(version: string, sel: InDocSelection) {
-  const selectedNodes = Array.from(sel.selection.children ?? []).map((x) => x.outerHTML);
+  const selectedNodes = Array.from(sel.selection.children ?? [])
+    .map((x) => x.outerHTML)
+    .filter(x => x.startsWith('<div class="'))
+    .map(x => x.substring(0, x.indexOf('>') + 1))
   const loc = JSON.stringify([
-    version,
+    version.substring(0, 10),
     sel.location.page,
     sel.location.section?.title,
     sel.location.subSection?.title,
@@ -52,8 +61,8 @@ export function deserializeLocation(h: string): LocationDetails | null {
     if (!Array.isArray(destringified)) {
       throw new Error(`parsed JSON is not an array: ${destringified} (${typeof destringified})`);
     }
-    const [version, page, section, subSection, selection] = destringified;
-    return { version, page, section, subSection, selection };
+    const [shortVersion, page, section, subSection, selection] = destringified;
+    return { shortVersion, page, section, subSection, selection };
   } catch (e) {
     console.warn("unable to decode hash", hash);
     console.warn(e);

--- a/src/utils/location.ts
+++ b/src/utils/location.ts
@@ -25,12 +25,13 @@ export function reserializeLocation(loc: LocationDetails) {
 }
 
 export function serializeLocation(version: string, sel: InDocSelection) {
+  const selectedNodes = Array.from(sel.selection.children ?? []).map((x) => x.outerHTML);
   const loc = JSON.stringify([
     version,
     sel.location.page,
     sel.location.section?.title,
     sel.location.subSection?.title,
-    Array.from(sel.selection.children ?? []).map((x) => x.outerHTML),
+    selectedNodes.length ? [selectedNodes[0], selectedNodes[selectedNodes.length - 1]] : [],
   ]);
 
   return btoa(unescape(encodeURIComponent(loc)));

--- a/src/utils/location.ts
+++ b/src/utils/location.ts
@@ -19,13 +19,7 @@ export function updateLocationVersion(version: string, hash: string): string | n
 }
 
 export function reserializeLocation(loc: LocationDetails) {
-  const l = JSON.stringify([
-    loc.shortVersion,
-    loc.page,
-    loc.section,
-    loc.subSection,
-    loc.selection
-  ]);
+  const l = JSON.stringify([loc.shortVersion, loc.page, loc.section, loc.subSection, loc.selection]);
 
   return btoa(unescape(encodeURIComponent(l)));
 }
@@ -33,8 +27,8 @@ export function reserializeLocation(loc: LocationDetails) {
 export function serializeLocation(version: string, sel: InDocSelection) {
   const selectedNodes = Array.from(sel.selection.children ?? [])
     .map((x) => x.outerHTML)
-    .filter(x => x.startsWith('<div class="'))
-    .map(x => x.substring(0, x.indexOf('>') + 1))
+    .filter((x) => x.startsWith('<div class="'))
+    .map((x) => x.substring(0, x.indexOf(">") + 1));
   const loc = JSON.stringify([
     version.substring(0, 10),
     sel.location.page,


### PR DESCRIPTION
Previously we were storing entire selection within the link. This is obviously sub-optimal, but was meant to be more future proof and help transition between versions.

However this causes that links are enormous and prohibitevely long for inclusion in code (doc comments) or messaging apps.

This PR shortens the links by:
1. Storing only the first and the last nodes of selection
2. Storing only classes of the `div` we care about, not the entire content.

Old links are backward compatible with this approach, since resolving the link was only using that information anyway.