### PR TITLE
Notes version indicator & migration.

### DIFF
--- a/src/components/Notes/Note.tsx
+++ b/src/components/Notes/Note.tsx
@@ -1,0 +1,135 @@
+import { type ChangeEvent, useCallback, useMemo, useState } from "react";
+import { Tooltip } from "react-tooltip";
+import { deserializeLocation, reserializeLocation, updateLocation } from "../../utils/location";
+
+export type NotesItem = {
+  location: string; // serialized InDocSelection
+  content: string;
+};
+
+type NoteProps = {
+  version: string;
+  note: NotesItem;
+  onEditNote: (n: NotesItem) => void;
+  onRemoveNote: (n: NotesItem) => void;
+};
+
+export function Note({ note, onEditNote, onRemoveNote, version }: NoteProps) {
+  const [isEditing, setIsEditing] = useState(false);
+
+  const toggleEdit = useCallback(() => {
+    if (isEditing) {
+      // defer change to prevent onBlur happening before clicks.
+      setTimeout(() => {
+        setIsEditing(false);
+      }, 300);
+    } else {
+      setIsEditing(true);
+    }
+  }, [isEditing]);
+
+  const editNote = useCallback(
+    (ev: ChangeEvent<HTMLTextAreaElement>) => {
+      note.content = ev.currentTarget.value;
+      onEditNote(note);
+    },
+    [note, onEditNote],
+  );
+
+  const removeNote = useCallback(() => {
+    onRemoveNote(note);
+  }, [note, onRemoveNote]);
+
+  const updateLocation = useCallback(
+    (href: string) => {
+      note.location = href;
+      onEditNote(note);
+    },
+    [note, onEditNote],
+  );
+
+  return (
+    <li>
+      <NoteLink note={note} version={version} onMigrate={updateLocation} />
+      {isEditing ? (
+        <textarea onChange={editNote} value={note.content} onBlur={toggleEdit} autoFocus />
+      ) : (
+        <blockquote onClick={toggleEdit} onKeyPress={toggleEdit}>
+          {note.content}
+        </blockquote>
+      )}
+      <button className="remove" style={{ display: isEditing ? "block" : "none" }} onClick={removeNote}>
+        delete
+      </button>
+    </li>
+  );
+}
+
+type NoteLinkProps = {
+  note: NotesItem;
+  version: string;
+  onMigrate: (location: string) => void;
+};
+function NoteLink({ note, version, onMigrate }: NoteLinkProps) {
+  const origLocDetails = useMemo(() => {
+    return deserializeLocation(note.location);
+  }, [note]);
+
+  const locDetails = useMemo(() => {
+    const origVersion = origLocDetails?.shortVersion;
+    if (origVersion) {
+      if (!version.startsWith(origVersion)) {
+        return updateLocation(origLocDetails, version);
+      }
+    }
+    return origLocDetails;
+  }, [origLocDetails, version]);
+
+  const newHref = useMemo(() => {
+    if (locDetails && origLocDetails !== locDetails) {
+      return reserializeLocation(locDetails);
+    }
+    return note.location;
+  }, [origLocDetails, locDetails, note]);
+
+  const migrateNote = useCallback(() => {
+    onMigrate(newHref);
+  }, [newHref, onMigrate]);
+
+  return (
+    <div>
+      {locDetails !== origLocDetails && (
+        <a
+          href={`#${note.location}`}
+          data-tooltip-id="note-link"
+          data-tooltip-content="This note was created in a different version. Click to open the original selection."
+          data-tooltip-place="top"
+          className="icon"
+        >
+          ⚠
+        </a>
+      )}
+      <a href={`#${newHref}`}>
+        {locDetails ? (
+          <span>
+            p:{Number(`0x${locDetails?.page}`)} &gt; {locDetails.section} &gt; {locDetails.subSection}
+          </span>
+        ) : (
+          "link"
+        )}
+      </a>
+      {locDetails !== origLocDetails && (
+        <a
+          onClick={migrateNote}
+          data-tooltip-id="note-link"
+          data-tooltip-content="Make sure the selection is accurate or adjust it in the current version and update the note."
+          data-tooltip-place="top"
+          className="update"
+        >
+          (migrate)
+        </a>
+      )}
+      <Tooltip id="note-link" />
+    </div>
+  );
+}

--- a/src/components/Notes/Notes.css
+++ b/src/components/Notes/Notes.css
@@ -21,3 +21,17 @@
 .notes blockquote:hover {
   border: 1px solid #eee;
 }
+
+.notes .icon {
+  margin-right: 3px;
+  color: #e22;
+  background-color: lightyellow;
+  padding: 2px;
+}
+
+.notes .update {
+  text-decoration: underline;
+  cursor: pointer;
+  margin-left: 3px;
+  color: #444;
+}

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -26,7 +26,7 @@ export function Sidebar({ iframeCtrl, metadata, onVersionChange, selectedVersion
   const [location, setLocation] = useState({ page: "0" } as InDocLocation);
   const [selection, setSelection] = useState(null as InDocSelection | null);
   const [outline, setOutline] = useState([] as OutlineType);
-  const [tab, setTab] = useState("outline");
+  const [tab, setTab] = useState(loadActiveTab());
 
   // perform one-time operations.
   useEffect(() => {
@@ -69,6 +69,11 @@ export function Sidebar({ iframeCtrl, metadata, onVersionChange, selectedVersion
       }
     };
   }, [iframeCtrl, onVersionChange, metadata]);
+
+  // store seletected tab in LS
+  useEffect(() => {
+    storeActiveTab(tab);
+  }, [tab]);
 
   const jumpTo = useCallback(
     (id: string) => {
@@ -115,4 +120,12 @@ function tabsContent(
       render: () => <Notes version={version} selection={selection} />,
     },
   ];
+}
+
+function storeActiveTab(tab: string) {
+  window.localStorage.setItem("gp-tab", tab);
+}
+
+function loadActiveTab(): string {
+  return window.localStorage.getItem("gp-tab") ?? "outline";
 }

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -11,6 +11,7 @@ type TabsProps = {
   activeTab: string;
   switchTab: (v: string) => void;
 };
+
 export function Tabs({ tabs, activeTab, switchTab }: TabsProps) {
   if (tabs.length === 0) {
     return null;

--- a/src/utils/location.ts
+++ b/src/utils/location.ts
@@ -14,13 +14,23 @@ export function updateLocationVersion(version: string, hash: string): string | n
     return null;
   }
 
-  loc.shortVersion = version.substring(0, 10);
-  return reserializeLocation(loc);
+  return reserializeLocation(loc, version);
 }
 
-export function reserializeLocation(loc: LocationDetails) {
-  const l = JSON.stringify([loc.shortVersion, loc.page, loc.section, loc.subSection, loc.selection]);
+export function updateLocation(loc: LocationDetails, version?: string): LocationDetails {
+  const shortVersion = version?.substring(0, 10) ?? loc.shortVersion;
+  return {
+    shortVersion,
+    page: loc.page,
+    section: loc.section,
+    subSection: loc.subSection,
+    selection: loc.selection,
+  };
+}
 
+export function reserializeLocation(originalLocation: LocationDetails, version?: string) {
+  const loc = updateLocation(originalLocation, version);
+  const l = JSON.stringify([loc.shortVersion, loc.page, loc.section, loc.subSection, loc.selection]);
   return btoa(unescape(encodeURIComponent(l)));
 }
 


### PR DESCRIPTION
Resolves #21 

<img width="376" alt="image" src="https://github.com/user-attachments/assets/35cb69a0-5255-4cd3-a2de-bd8700fe2c92">

After the PR, every note will link to the currently selected version (we try to re-create the selection). If the note was however added on a different version, there is a small warning icon displayed that can take you to the original location.

After verifying the note is correctly anchored in the latest document (or simply adjusting the selection), the user can "migrate" the note.