### PR TITLE
Make table borders visible in light mode

### DIFF
--- a/src/utils/IframeController.tsx
+++ b/src/utils/IframeController.tsx
@@ -37,7 +37,7 @@ img {
 }
 
 body.theme-light img.bi {
-  display: none;
+  filter: invert(100%) brightness(150%);
 }
 body.theme-light .fc0 {
   color: #111;


### PR DESCRIPTION
I did a small change in the styles that are used to render light theme. I inverted colours and made it a bit brighter instead of disabling background:

Before:
<img width="818" alt="Screenshot 2024-08-14 at 10 29 01" src="https://github.com/user-attachments/assets/eaa126e2-3054-45bb-8945-7e413d179114">
<img width="821" alt="Screenshot 2024-08-14 at 10 29 51" src="https://github.com/user-attachments/assets/5d72c257-f3fc-486f-87cc-5aea48a90c60">

After:
<img width="816" alt="Screenshot 2024-08-14 at 10 35 48" src="https://github.com/user-attachments/assets/f667e8b8-882a-4c27-abbc-af5e7e3bdbe8">
<img width="800" alt="Screenshot 2024-08-14 at 10 35 39" src="https://github.com/user-attachments/assets/294ef1e7-3d3b-49fe-8650-de265dae2eb1">

It is not perfect but I think it is much better.


This PR closes https://github.com/FluffyLabs/graypaper-reader/issues/32