### PR TITLE
Bugfix: some blocks were skipped during selection

### DIFF
--- a/src/components/LocationProvider/LocationProvider.tsx
+++ b/src/components/LocationProvider/LocationProvider.tsx
@@ -107,13 +107,22 @@ export function LocationProvider({ children }: ILocationProviderProps) {
 
   const synctexBlocksToSelectionParams: ILocationContext["synctexBlocksToSelectionParams"] = (blocks) => {
     const blockIds = blocks.map((block) => ({ pageNumber: block.pageNumber, index: block.index }));
+    const lowestBlockId = blockIds.reduce((result, blockId) => {
+      if (blockId.pageNumber < result.pageNumber) return blockId;
+      if (blockId.pageNumber === result.pageNumber && blockId.index < result.index) return blockId;
+
+      return result;
+    }, blockIds[0]);
+    const highestBlockId = blockIds.reduce((result, blockId) => {
+      if (blockId.pageNumber > result.pageNumber) return blockId;
+      if (blockId.pageNumber === result.pageNumber && blockId.index > result.index) return blockId;
+
+      return result;
+    }, blockIds[0]);
 
     return {
-      selectionStart: { pageNumber: blockIds[0].pageNumber, index: blockIds[0].index },
-      selectionEnd: {
-        pageNumber: blockIds[blockIds.length - 1].pageNumber,
-        index: blockIds[blockIds.length - 1].index,
-      },
+      selectionStart: lowestBlockId,
+      selectionEnd: highestBlockId,
     };
   };
 

--- a/src/components/SelectionProvider/SelectionProvider.tsx
+++ b/src/components/SelectionProvider/SelectionProvider.tsx
@@ -71,6 +71,7 @@ export function SelectionProvider({ children }: ISelectionProviderProps) {
         (rect.top + rect.height / 2 - pageRect.top) / pageRect.height,
         pageNumber,
       );
+      console.log(synctexBlock?.pageNumber, synctexBlock?.index);
 
       if (synctexBlock && synctexBlocks.indexOf(synctexBlock) === -1) {
         synctexBlocks.push(synctexBlock);

--- a/src/components/SelectionProvider/SelectionProvider.tsx
+++ b/src/components/SelectionProvider/SelectionProvider.tsx
@@ -71,7 +71,6 @@ export function SelectionProvider({ children }: ISelectionProviderProps) {
         (rect.top + rect.height / 2 - pageRect.top) / pageRect.height,
         pageNumber,
       );
-      console.log(synctexBlock?.pageNumber, synctexBlock?.index);
 
       if (synctexBlock && synctexBlocks.indexOf(synctexBlock) === -1) {
         synctexBlocks.push(synctexBlock);


### PR DESCRIPTION
- Improved selection accuracy where synctex blocks are stored in a different order than they're rendered in.