### PR TITLE
Fix scrolling to outline links

### DIFF
--- a/src/components/Outline/Outline.tsx
+++ b/src/components/Outline/Outline.tsx
@@ -46,9 +46,5 @@ function Link({ dest, children }: ILinkProps) {
     linkService?.goToDestination(dest);
   }, [linkService, dest]);
 
-  return (
-    <a onClick={handleClick}>
-      {children}
-    </a>
-  );
+  return <a onClick={handleClick}>{children}</a>;
 }

--- a/src/components/Outline/Outline.tsx
+++ b/src/components/Outline/Outline.tsx
@@ -47,7 +47,7 @@ function Link({ dest, children }: ILinkProps) {
   }, [linkService, dest]);
 
   return (
-    <a href="#" onClick={handleClick}>
+    <a onClick={handleClick}>
       {children}
     </a>
   );

--- a/src/components/PdfViewer/PdfViewer.css
+++ b/src/components/PdfViewer/PdfViewer.css
@@ -8,6 +8,10 @@
   padding: inherit;
 }
 
+.pdfViewer {
+  width: fit-content;
+}
+
 .pdfViewer.light-theme {
   filter: invert(1) contrast(1.5);
 }

--- a/src/components/PdfViewer/PdfViewer.tsx
+++ b/src/components/PdfViewer/PdfViewer.tsx
@@ -64,6 +64,7 @@ export function PdfViewer() {
 
       const pdfViewer = new pdfJsViewer.PDFViewer({
         container: rootElement,
+        viewer: viewerContainer,
         eventBus,
         linkService,
         findController,


### PR DESCRIPTION
Fixes #73 

The issue was with internal pdfjs detecting which elements should be scrolled.
Our `.pdfViewer` element was correctly expanding the `height` attribute to fit the content (all pages), but the `width` was for some reason clamped to the width of the parent element (despite the parent element having `overflow: auto`).
Due to this, the internal pdfjs library was trying to scroll the `.pdfViewer` instead of the parent element that is scrolled in the other case.

Setting `width: fit-content` fixed that issue, so now pdfjs internally jump to the parent of the `.pdfViewer` and scrolls that.