### PR TITLE
Make note transparent on mouse over

### DIFF
--- a/src/components/NoteRenderer/components/HighlightNote/HighlightNote.tsx
+++ b/src/components/NoteRenderer/components/HighlightNote/HighlightNote.tsx
@@ -27,7 +27,7 @@ export function HighlightNote({ note, pageOffset }: HighlightNoteProps) {
   const rightmostEdge = Math.max(...blocks.map(({ left, width }) => left + width));
   const leftmostEdge = Math.min(...blocks.map(({ left }) => left));
 
-  const style =
+  const position =
     rightmostEdge > 0.5
       ? {
           left: `${pageOffset.left + rightmostEdge * pageOffset.width}px`,
@@ -37,6 +37,11 @@ export function HighlightNote({ note, pageOffset }: HighlightNoteProps) {
           right: `${pageOffset.right - pageOffset.width + (1 - leftmostEdge) * pageOffset.width}px`,
           top: `${pageOffset.top + pageOffset.height * blocks[blocks.length - 1].top - noteContentHeight}px`,
         };
+
+  const style = {
+    opacity: noteIsShown ? 1.0 : 0.1,
+    ...position,
+  };
 
   const handleNoteContentRef = (noteContentElement: HTMLDivElement) =>
     setNoteContentHeight(noteContentElement?.offsetHeight || 0);
@@ -48,7 +53,7 @@ export function HighlightNote({ note, pageOffset }: HighlightNoteProps) {
       <div
         className="highlight-note-content"
         ref={handleNoteContentRef}
-        style={Object.assign({}, noteIsShown ? { opacity: 1 } : { opacity: 0.1 }, style)}
+        style={style}
         onMouseEnter={() => setNoteIsShown(false)}
         onMouseLeave={() => setNoteIsShown(true)}
       >

--- a/src/components/NoteRenderer/components/HighlightNote/HighlightNote.tsx
+++ b/src/components/NoteRenderer/components/HighlightNote/HighlightNote.tsx
@@ -15,10 +15,11 @@ const NOTE_OPACITY = 0.5;
 export function HighlightNote({ note, pageOffset }: HighlightNoteProps) {
   const [noteContentHeight, setNoteContentHeight] = useState<number>(0);
   const { getSynctexBlockRange } = useContext(CodeSyncContext) as ICodeSyncContext;
+  const [noteIsShown, setNoteIsShown] = useState(true);
 
   const blocks = useMemo(
     () => getSynctexBlockRange(note.selectionStart, note.selectionEnd),
-    [note, getSynctexBlockRange],
+    [note, getSynctexBlockRange]
   );
 
   if (!blocks.length) return null;
@@ -44,7 +45,13 @@ export function HighlightNote({ note, pageOffset }: HighlightNoteProps) {
     <>
       <Highlighter blocks={blocks} pageOffset={pageOffset} color={NOTE_COLOR} opacity={NOTE_OPACITY} />
 
-      <div className="highlight-note-content" ref={handleNoteContentRef} style={style}>
+      <div
+        className="highlight-note-content"
+        ref={handleNoteContentRef}
+        style={Object.assign({}, noteIsShown ? { opacity: 1 } : { opacity: 0.1 }, style)}
+        onMouseEnter={() => setNoteIsShown(false)}
+        onMouseLeave={() => setNoteIsShown(true)}
+      >
         {note.content}
       </div>
     </>

--- a/src/components/NoteRenderer/components/HighlightNote/HighlightNote.tsx
+++ b/src/components/NoteRenderer/components/HighlightNote/HighlightNote.tsx
@@ -19,7 +19,7 @@ export function HighlightNote({ note, pageOffset }: HighlightNoteProps) {
 
   const blocks = useMemo(
     () => getSynctexBlockRange(note.selectionStart, note.selectionEnd),
-    [note, getSynctexBlockRange]
+    [note, getSynctexBlockRange],
   );
 
   if (!blocks.length) return null;


### PR DESCRIPTION
This is implementing [the option 1](https://github.com/FluffyLabs/graypaper-reader/issues/75#issuecomment-2440636556) of @tomusdrw comment.
Only thing that worries me with this solution is that it will not allow #53 to be implemented as hover will make the note transparent.
I will open a new PR for the note to have a button that will allow to minimize/maximize it. Feel free to close this if you feel that solution is in conflict with #53 