### PR TITLE
[85] Add version name to location hash url

### DIFF
--- a/src/components/LocationProvider/LocationProvider.tsx
+++ b/src/components/LocationProvider/LocationProvider.tsx
@@ -46,7 +46,7 @@ export function LocationProvider({ children }: ILocationProviderProps) {
       const version =
         newParams?.version.substring(0, SHORT_COMMIT_HASH_LENGTH) ||
         metadata.versions[metadata.latest]?.hash.substring(0, SHORT_COMMIT_HASH_LENGTH);
-      const versionName = metadata.versions[newParams?.version ?? metadata.latest]?.name;
+      const versionName = newParams ? metadata.versions[newParams.version]?.name : undefined;
 
       const stringifiedParams = [];
 
@@ -59,7 +59,8 @@ export function LocationProvider({ children }: ILocationProviderProps) {
         ].join("");
       }
 
-      window.location.hash = `${SEGMENT_SEPARATOR}${stringifiedParams.join(SEGMENT_SEPARATOR)}?v=${versionName}`;
+      const newHash = `${SEGMENT_SEPARATOR}${stringifiedParams.join(SEGMENT_SEPARATOR)}`;
+      window.location.hash = versionName ? `${newHash}?v=${versionName}` : newHash;
     },
     [metadata],
   );

--- a/src/components/LocationProvider/LocationProvider.tsx
+++ b/src/components/LocationProvider/LocationProvider.tsx
@@ -46,6 +46,7 @@ export function LocationProvider({ children }: ILocationProviderProps) {
       const version =
         newParams?.version.substring(0, SHORT_COMMIT_HASH_LENGTH) ||
         metadata.versions[metadata.latest]?.hash.substring(0, SHORT_COMMIT_HASH_LENGTH);
+      const versionName = metadata.versions[newParams?.version ?? metadata.latest]?.name;
 
       const stringifiedParams = [];
 
@@ -58,7 +59,7 @@ export function LocationProvider({ children }: ILocationProviderProps) {
         ].join("");
       }
 
-      window.location.hash = `${SEGMENT_SEPARATOR}${stringifiedParams.join(SEGMENT_SEPARATOR)}`;
+      window.location.hash = `${SEGMENT_SEPARATOR}${stringifiedParams.join(SEGMENT_SEPARATOR)}?v=${versionName}`;
     },
     [metadata],
   );


### PR DESCRIPTION
#85 
- added human readable version name in hash url
ex.
prev: https://graypaper.fluffylabs.dev/#/5f542d7/011500013200
now: https://graypaper.fluffylabs.dev/#/5f542d7/011500013200?v=0.6.2