### PR TITLE
Make highlights less annoying.

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -34,6 +34,7 @@
   flex-direction: column-reverse;
   opacity: 0.7;
   transition: opacity ease-in 250ms;
+  z-index: 10;
 }
 @media (max-width: 768px) {
   .controls {

--- a/src/components/PdfViewer/Highlighter/Highlighter.css
+++ b/src/components/PdfViewer/Highlighter/Highlighter.css
@@ -1,4 +1,12 @@
 .highlighter-highlight {
   position: absolute;
+  pointer-events: none;
+}
+.highlighter-trigger {
+  position: absolute;
   cursor: pointer;
+}
+.highlighter-trigger:hover {
+  transition: opacity 200ms ease-in-out;
+  opacity: 1.0 !important;
 }

--- a/src/components/PdfViewer/NoteRenderer/components/HighlightNote/HighlightNote.tsx
+++ b/src/components/PdfViewer/NoteRenderer/components/HighlightNote/HighlightNote.tsx
@@ -14,7 +14,7 @@ interface HighlightNoteProps {
 }
 
 const NOTE_COLOR = { r: 200, g: 200, b: 0 };
-const NOTE_OPACITY = 0.5;
+const NOTE_OPACITY = 0.3;
 const HOVER_OFF_DELAY_MS = 350;
 
 export function HighlightNote({ notes, pageOffset, isInViewport, isPinnedByDefault }: HighlightNoteProps) {
@@ -86,7 +86,7 @@ export function HighlightNote({ notes, pageOffset, isInViewport, isPinnedByDefau
   // We should rather display one highlight and have it open both notes,
   // or be able to select which note to open.
   return (
-    <div>
+    <>
       <Highlighter
         blocks={blocks}
         pageOffset={pageOffset}
@@ -116,6 +116,6 @@ export function HighlightNote({ notes, pageOffset, isInViewport, isPinnedByDefau
           </Fragment>
         ))}
       </div>
-    </div>
+    </>
   );
 }

--- a/src/components/PdfViewer/PdfViewer.css
+++ b/src/components/PdfViewer/PdfViewer.css
@@ -25,6 +25,13 @@
   filter: invert(1);
 }
 
+.pdfViewer .textLayer {
+  /* Bump the z-index of text layer, so that we can display highlights
+   * between the page background and the text layer (selection is on top)
+   */
+  z-index: 1;
+}
+
 .pdfViewer.gray .textLayer ::selection,
 .pdfViewer.light .textLayer ::selection {
   background: rgba(255, 155, 50, 0.25);

--- a/src/components/PdfViewer/SelectionRenderer/SelectionRenderer.tsx
+++ b/src/components/PdfViewer/SelectionRenderer/SelectionRenderer.tsx
@@ -7,8 +7,7 @@ import { Highlighter, type IHighlighterColor } from "../Highlighter/Highlighter"
 import { useTextLayer } from "../utils";
 
 const SELECTION_COLOR: IHighlighterColor = { r: 0, g: 100, b: 200 };
-const SELECTION_OPACITY = 0.5;
-const SELECTION_ZINDEX = 2;
+const SELECTION_OPACITY = 0.3;
 const SCROLL_TO_OFFSET_PX: number = 200;
 
 export function SelectionRenderer() {
@@ -114,13 +113,7 @@ export function SelectionRenderer() {
   if (!viewer || !pageOffset) return null;
 
   return (
-    <Highlighter
-      blocks={selectedBlocks}
-      pageOffset={pageOffset}
-      color={SELECTION_COLOR}
-      opacity={SELECTION_OPACITY}
-      zIndex={SELECTION_ZINDEX}
-    />
+    <Highlighter blocks={selectedBlocks} pageOffset={pageOffset} color={SELECTION_COLOR} opacity={SELECTION_OPACITY} />
   );
 }
 


### PR DESCRIPTION
1. Moves highlights below the text layer (so it's possible to select text over the highlight).
2. Introduce a separate "trigger" element that opens the note instead of the entire highlight (required because of (1) - highlight below text = no pointer events)
3. Avoid rendering fully-contained blocks on top of each other (background alpha stacking made it hard to read some text)