### PR TITLE
Clean old default sources from local storage.

### DIFF
--- a/src/components/NotesProvider/utils/remoteSources.spec.ts
+++ b/src/components/NotesProvider/utils/remoteSources.spec.ts
@@ -1,0 +1,25 @@
+import { expect, test } from "vitest";
+import type { IRemoteSource } from "../types/RemoteSource";
+import { DEFAULT_SOURCES, updateDefaultSources } from "./remoteSources";
+
+const exampleSources: IRemoteSource[] = [
+  {
+    id: 5,
+    name: "My source",
+    url: "https://xxx",
+    isEnabled: true,
+    versions: [],
+  },
+  ...DEFAULT_SOURCES,
+  {
+    id: -9999999,
+    name: "My old default source",
+    url: "https://zzz",
+    isEnabled: true,
+    versions: [],
+  },
+];
+
+test("should filter out the sources", () => {
+  expect(updateDefaultSources(exampleSources)).toEqual([exampleSources[0], ...DEFAULT_SOURCES]);
+});

--- a/src/components/NotesProvider/utils/remoteSources.ts
+++ b/src/components/NotesProvider/utils/remoteSources.ts
@@ -12,7 +12,7 @@ const VERSIONS_0_6_X = [
 ];
 
 // negative indices to avoid conflicts with user-added sources.
-const DEFAULT_SOURCES = [
+export const DEFAULT_SOURCES = [
   {
     id: -6,
     name: "Element Activity (v0.6.x)",
@@ -29,7 +29,7 @@ const DEFAULT_SOURCES = [
   },
 ];
 
-function updateDefaultSources(sources: IRemoteSource[]) {
+export function updateDefaultSources(sources: IRemoteSource[]) {
   const ids = sources.map((x) => x.id);
   for (const def of DEFAULT_SOURCES) {
     const idx = ids.indexOf(def.id);
@@ -40,7 +40,20 @@ function updateDefaultSources(sources: IRemoteSource[]) {
       sources[idx] = { ...def, isEnabled: sources[idx].isEnabled };
     }
   }
-  return sources;
+  // remove default, but old sources that got removed.
+  const newSources: IRemoteSource[] = [];
+  for (const source of sources) {
+    let shouldStay = true;
+    // only keep the default source if it's still present.
+    if (source.id < 0) {
+      shouldStay = DEFAULT_SOURCES.findIndex((x) => x.id === source.id) !== -1;
+    }
+
+    if (shouldStay) {
+      newSources.push(source);
+    }
+  }
+  return newSources;
 }
 
 export function loadFromLocalStorage(): IRemoteSource[] {


### PR DESCRIPTION
I've noticed that old remote sources (removed in #211) still stay in the local storage and the user is unable to remove them from settings, because they have negative ids and don't display the remove button.

This PR clears the remote sources (with negative ids) that are found in the local storage, yet are not present in the `DEFAULT_SOURCES` constant any more.