### PR TITLE
style: fix outline style - use border instead of underline; make it dimmer

### DIFF
--- a/src/components/Outline/Outline.tsx
+++ b/src/components/Outline/Outline.tsx
@@ -65,39 +65,50 @@ const OutlineDumb: FC<{
 
     return (
       <ul className={twMerge(firstLevel ? "mt-0" : "my-3", className)}>
-        {outline.map((item, index) => (
-          <li key={item.title} className={twMerge(firstLevel ? "pl-0 mt-4" : "pl-4", "mt-0.5 first-of-type:mt-0")}>
-            {isSkeleton && (
-              <OutlineLinkSkeleton
-                className={twMerge(
-                  "h-4.5",
-                  index % 4 === 0 && "w-52",
-                  index % 4 === 1 && "w-64",
-                  index % 4 === 2 && "w-48",
-                  index % 4 === 3 && "w-24",
-                  !firstLevel && "mt-0.5",
-                  "max-w-10/12",
-                )}
-              />
-            )}
-            {!isSkeleton && (
-              <Link
-                dest={item.dest}
-                onClick={onClick}
-                className={twMerge(
-                  "border-b-1",
-                  !firstLevel &&
-                    "dark:text-brand-light dark:border-brand-light/50 text-brand-dark border-brand-dark/50 mt-0.5",
-                  firstLevel && "dark:text-brand dark:border-brand/50 text-brand-darkest border-brand-darkest/50 ",
-                )}
-              >
-                {firstLevel && item.title.replace(".", " > ")}
-                {!firstLevel && item.title}
-              </Link>
-            )}
-            {item.items.length > 0 ? renderOutline(item.items, { isSkeleton }) : null}
-          </li>
-        ))}
+        {outline.map((item, index) => {
+          const { title, number } = splitOutlineTitle(item.title);
+          return (
+            <li key={item.title} className={twMerge(firstLevel ? "pl-0 mt-4" : "pl-4", "mt-0.5 first-of-type:mt-0")}>
+              {isSkeleton && (
+                <OutlineLinkSkeleton
+                  className={twMerge(
+                    "h-4.5",
+                    index % 4 === 0 && "w-52",
+                    index % 4 === 1 && "w-64",
+                    index % 4 === 2 && "w-48",
+                    index % 4 === 3 && "w-24",
+                    !firstLevel && "mt-0.5",
+                    "max-w-10/12",
+                  )}
+                />
+              )}
+              {!isSkeleton && (
+                <Link
+                  dest={item.dest}
+                  onClick={onClick}
+                  className={twMerge(
+                    !firstLevel && "dark:text-brand-light text-brand-dark mt-0.5",
+                    firstLevel && "dark:text-brand text-brand-darkest",
+                  )}
+                >
+                  {firstLevel && (
+                    <>
+                      <span>{number?.replace(".", " >")}</span>&nbsp;
+                      <span className="border-b-1 dark:border-brand/50 border-brand-darkest/50">{title}</span>
+                    </>
+                  )}
+                  {!firstLevel && (
+                    <>
+                      <span>{number}</span>&nbsp;
+                      <span className="border-b-1 dark:border-brand-light/50 border-brand-dark/50">{title}</span>
+                    </>
+                  )}
+                </Link>
+              )}
+              {item.items.length > 0 ? renderOutline(item.items, { isSkeleton }) : null}
+            </li>
+          );
+        })}
       </ul>
     );
   };
@@ -126,4 +137,21 @@ function Link({ dest, children, className, onClick }: ILinkProps) {
       {children}
     </a>
   );
+}
+
+function splitOutlineTitle(title: string): { number: string | null; title: string } {
+  const regex = /^((?:\d+(?:\.\d+)?|Appendix [A-Z]|[A-Z]\.\d+)\.)\s*(.+)$/;
+  const match = title.match(regex);
+
+  if (match) {
+    return {
+      number: match[1],
+      title: match[2],
+    };
+  }
+
+  return {
+    number: null,
+    title: title,
+  };
 }

--- a/src/components/Outline/Outline.tsx
+++ b/src/components/Outline/Outline.tsx
@@ -85,9 +85,10 @@ const OutlineDumb: FC<{
                 dest={item.dest}
                 onClick={onClick}
                 className={twMerge(
-                  "underline underline-offset-2",
-                  !firstLevel && "dark:text-brand-light text-brand-dark mt-0.5",
-                  firstLevel && "dark:text-brand text-brand-darkest",
+                  "border-b-1",
+                  !firstLevel &&
+                    "dark:text-brand-light dark:border-brand-light/50 text-brand-dark border-brand-dark/50 mt-0.5",
+                  firstLevel && "dark:text-brand dark:border-brand/50 text-brand-darkest border-brand-darkest/50 ",
                 )}
               >
                 {firstLevel && item.title.replace(".", " > ")}


### PR DESCRIPTION
**What**
- border used instead of underline
- color of the border is the same as text's but 50% opacity 


<img width="573" height="656" alt="Screenshot 2025-08-25 at 21 38 29" src="https://github.com/user-attachments/assets/2c8f4dc7-6ef6-49fe-a007-dfa9fb072fbe" />
<img width="569" height="663" alt="Screenshot 2025-08-25 at 21 38 35" src="https://github.com/user-attachments/assets/59384ac7-953f-4907-9288-427f85486976" />
