### PR TITLE
style: fix dark/light colors

### DIFF
--- a/src/components/NoteManager/components/NotesList.tsx
+++ b/src/components/NoteManager/components/NotesList.tsx
@@ -12,7 +12,7 @@ export const NotesList = ({
   onDeleteNote: (noteToDelete: IDecoratedNote) => void;
 }) => {
   if (notes.length === 0) {
-    return <div className="no-notes">No notes available.</div>;
+    return <div className="no-notes text-sidebar-foreground">No notes available.</div>;
   }
 
   return (

--- a/src/components/PdfViewer/PdfViewer.css
+++ b/src/components/PdfViewer/PdfViewer.css
@@ -17,6 +17,10 @@
   min-width: fit-content;
 }
 
+.pdfViewer .page{
+  background-color: #101010;
+}
+
 .pdfViewer.light .page{
   filter: invert(1) contrast(1.6);
 }
@@ -39,9 +43,4 @@
 
 .pdfViewer .textLayer ::selection {
   background: rgba(0, 50, 255, 0.25);
-}
-
-.pdfViewer .page {
-  background-color: var(--sidebar)
-
 }

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -174,7 +174,7 @@ function SearchResults({ query, onSearchFinished }: SearchResultsProps) {
           ➡️
         </button>
       </div>
-      <div className={`search-results ${isLoading ? "search-loading" : ""}`}>
+      <div className={`search-results text-sidebar-foreground ${isLoading ? "search-loading" : ""}`}>
         Found {matches.count} results on {matches.pagesAndCount.length} pages.
         <ul>
           {matches.pagesAndCount.map((res) => (

--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -9,6 +9,18 @@
   --brand-dark: rgb(18 152 141);
   --brand-very-dark: rgb(14 116 107);
   --brand-darkest: rgb(14 53 50);
+
+  --sidebar-foreground: var(--color-gray-600);
+
+    color-scheme: light;
+}
+
+.dark{
+  --sidebar-foreground: rgb(255 255 255);
+  --sidebar-foreground: var(--color-gray-300);
+  /* Force light mode rendering */
+
+  color-scheme: dark;
 }
 
 @theme{
@@ -18,6 +30,8 @@
   --color-brand-very-dark: var(--brand-very-dark);
   --color-brand-light: var(--brand-light);
   --color-brand-very-light: var(--brand-very-light);
+
+  --color-sidebar-foreground: var(--sidebar-foreground);
 
   --animate-fade-in: fade-in 0.75s ease-in forwards;
 


### PR DESCRIPTION
**What?**
- fixed backgrounds of pdf viewr pages to match correctly dark/light modes
- fixed some colors that wrongly picked dark/light colors in right side bar due to css's `light-dark() function` was not setup with app's dark/light theme 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated PDF viewer page background to a fixed dark tone for clearer page contrast.
  * Improved text color in empty note states and search results to align with sidebar foreground styling.
  * Introduced a theme-aware sidebar foreground color variable, enhancing readability in light and dark modes.
  * Minor visual refinements applied without changing behavior or user flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->