### PR TITLE
fix: loading of labels indicator

### DIFF
--- a/src/components/LabelsFilter/LabelsFilter.tsx
+++ b/src/components/LabelsFilter/LabelsFilter.tsx
@@ -21,16 +21,12 @@ const emptyLabels: ILabelTreeNode[] = [];
 const emptyCallback = () => {};
 
 export function LabelsFilter({ forcedColorScheme }: { forcedColorScheme?: "dark" | "light" }) {
-  const {
-    labels = emptyLabels,
-    handleToggleLabel = emptyCallback,
-    labelsAreLoaded = false,
-  } = useContext(NotesContext) ?? {};
+  const { labels = emptyLabels, handleToggleLabel = emptyCallback, notesReady } = useContext(NotesContext) ?? {};
 
   return (
     <LabelsFilterDumb
       labels={labels}
-      labelsAreLoaded={labelsAreLoaded}
+      labelsAreLoaded={notesReady ?? false}
       onToggleLabel={handleToggleLabel}
       forcedColorScheme={forcedColorScheme}
     />

--- a/src/components/LabelsFilter/LabelsFilter.tsx
+++ b/src/components/LabelsFilter/LabelsFilter.tsx
@@ -3,6 +3,7 @@ import {
   DropdownMenu,
   DropdownMenuCheckboxItem,
   DropdownMenuContent,
+  DropdownMenuLabel,
   DropdownMenuTrigger,
 } from "@fluffylabs/shared-ui";
 import { type FC, Fragment, useCallback, useContext, useMemo } from "react";
@@ -86,6 +87,7 @@ const LabelsFilterDumb: FC<{
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent className="w-auto max-w-72" align="end" forcedColorScheme={forcedColorScheme}>
+        {treeRoots.length === 0 && <DropdownMenuLabel className="text-center opacity-65">No labels</DropdownMenuLabel>}
         {treeRoots.map((label) => (
           <Fragment key={label.prefixedLabel}>
             <DropdownMenuCheckboxItem

--- a/src/components/NotesProvider/NotesProvider.tsx
+++ b/src/components/NotesProvider/NotesProvider.tsx
@@ -94,7 +94,7 @@ export function NotesProvider({ children }: INotesProviderProps) {
 
   const allNotesReady = useMemo(() => localNotesReady && remoteNotesReady, [localNotesReady, remoteNotesReady]);
 
-  const { filteredNotes, labels, labelsAreLoaded, toggleLabel: handleToggleLabel } = useLabels(allNotes);
+  const { filteredNotes, labels, toggleLabel: handleToggleLabel } = useLabels(allNotes);
 
   const context: INotesContext = {
     notesPinned,
@@ -105,7 +105,7 @@ export function NotesProvider({ children }: INotesProviderProps) {
     labels,
     canUndo,
     canRedo,
-    labelsAreLoaded,
+    labelsAreLoaded: allNotesReady,
     handleSetRemoteSources: useCallback((newVal: IRemoteSource, remove?: true) => {
       setRemoteSources((remoteSources) => {
         let newRemoteSources = remoteSources;

--- a/src/components/NotesProvider/NotesProvider.tsx
+++ b/src/components/NotesProvider/NotesProvider.tsx
@@ -25,7 +25,6 @@ export interface INotesContext {
   canUndo: boolean;
   canRedo: boolean;
   remoteSources: IRemoteSource[];
-  labelsAreLoaded: boolean;
   handleSetRemoteSources(r: IRemoteSource, remove?: true): void;
   handleAddNote(note: IStorageNote): void;
   handleUpdateNote(noteToReplace: IDecoratedNote, newNote: IStorageNote): void;
@@ -122,7 +121,6 @@ export function NotesProvider({ children }: INotesProviderProps) {
     labels,
     canUndo,
     canRedo,
-    labelsAreLoaded: allNotesReady,
     handleSetRemoteSources,
     handleToggleLabel,
     handleAddNote: useCallback(

--- a/src/components/NotesProvider/hooks/useLabels.ts
+++ b/src/components/NotesProvider/hooks/useLabels.ts
@@ -109,7 +109,7 @@ export function getFilteredNotes<T extends IStorageNote | IDecoratedNote>(
   });
 }
 
-const emptyArray: unknown[] = [];
+const initialEmptyArray: unknown[] = [];
 
 /**
  * Maintains a list list of all labels (across all nodes) and allow to activate/deactivate them
@@ -119,10 +119,9 @@ export function useLabels(allNotes: IDecoratedNote[]): {
   filteredNotes: IDecoratedNote[];
   labels: ILabelTreeNode[];
   toggleLabel: (label: ILabelTreeNode) => void;
-  labelsAreLoaded: boolean;
 } {
   const [storageLabels, setStorageLabels] = useState<IStorageLabel[]>([]);
-  const [labels, setLabels] = useState<ILabelTreeNode[]>(emptyArray as ILabelTreeNode[]);
+  const [labels, setLabels] = useState<ILabelTreeNode[]>(initialEmptyArray as ILabelTreeNode[]);
 
   // load and save storage labels to Local Storage
   useEffect(() => {
@@ -234,5 +233,5 @@ export function useLabels(allNotes: IDecoratedNote[]): {
     return getFilteredNotes(allNotes, activeLabels);
   }, [allNotes, labels]);
 
-  return { filteredNotes, labels, toggleLabel, labelsAreLoaded: labels !== emptyArray };
+  return { filteredNotes, labels, toggleLabel };
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added an empty-state message in the Labels filter dropdown showing “No labels” when none are available.

- Bug Fixes
  - Labels loading state now reflects overall notes readiness, preventing premature or confusing label availability while notes finish loading.

- Style
  - Polished the dropdown’s empty-state appearance with centered, subtly dimmed text for clearer feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->