### PR TITLE
fix: wrong position of pdf selection boxes

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -3,14 +3,6 @@
   height: 100vh;
 }
 
-.pdf-viewer-container {
-  box-sizing: border-box;
-  height: 100%;
-  width: 100%;
-  position: relative;
-  overflow: hidden;
-  background-color: #999;
-}
 
 .viewer {
   box-sizing: border-box;

--- a/src/components/PdfViewer/PdfViewer.css
+++ b/src/components/PdfViewer/PdfViewer.css
@@ -52,3 +52,11 @@
 .pdfViewer .textLayer .endOfContent, .pdfViewer .textLayer br{
   pointer-events: none;
 }
+
+.pdf-viewer-root {
+  position: absolute
+}
+
+.pdf-viewer-root, .pdf-viewer-root *, .pdf-viewer-root :after, .pdf-viewer-root :before {
+  box-sizing: initial;
+}

--- a/src/components/PdfViewer/PdfViewer.tsx
+++ b/src/components/PdfViewer/PdfViewer.tsx
@@ -114,21 +114,19 @@ export function PdfViewer() {
     );
 
   return (
-    <>
-      <div
-        ref={handleRootRef}
-        className="pdf-viewer-root bg-inherit"
-        onMouseDown={removeSelection}
-        onMouseUp={handleViewerMouseUp}
-        onWheel={handleWheel}
-      >
-        {pagesLoaded ? (
-          <>
-            <NoteRenderer />
-            <SelectionRenderer />
-          </>
-        ) : null}
-      </div>
-    </>
+    <div
+      ref={handleRootRef}
+      className="pdf-viewer-root bg-inherit absolute"
+      onMouseDown={removeSelection}
+      onMouseUp={handleViewerMouseUp}
+      onWheel={handleWheel}
+    >
+      {pagesLoaded ? (
+        <>
+          <NoteRenderer />
+          <SelectionRenderer />
+        </>
+      ) : null}
+    </div>
   );
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved PDF viewer positioning to prevent clipping and overflow.
  - Ensured consistent box sizing within the viewer for more predictable layouts.
  - Removed outdated container styles that could cause layout conflicts.
- Style
  - Applied absolute positioning to the viewer root for stable placement.
  - Preserved visual consistency with inherited background.
- Refactor
  - Simplified component structure by removing an unnecessary wrapper.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->