### PR TITLE
fix: clear textLayerRendered ref on unmount

### DIFF
--- a/src/components/PdfProvider/hooks/useTextLayerRendered.ts
+++ b/src/components/PdfProvider/hooks/useTextLayerRendered.ts
@@ -18,6 +18,7 @@ export function useTextLayerRendered(eventBus: pdfJsViewer.EventBus | undefined)
     eventBus.on("textlayerrendered", handleTextLayerRendered);
 
     return () => {
+      textLayerRenderedRef.current = [];
       eventBus.off("textlayerrendered", handleTextLayerRendered);
     };
   }, [eventBus]);


### PR DESCRIPTION
Add missing change from previous PR  #333 ; add clearing ref value on unmount

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory management when PDF components unmount, ensuring proper resource cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->