### PR TITLE
feat: add nightly update mode to auto-update workflow

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -5,6 +5,15 @@ on:
     branches:
       - 'feature/auto-update-workflow'
   workflow_dispatch:
+    inputs:
+      update_mode:
+        description: 'Update mode: tag (latest release) or nightly (latest main branch)'
+        required: false
+        default: 'tag'
+        type: choice
+        options:
+          - tag
+          - nightly
   schedule:
     - cron: "51 13 * * *" # using an arbitrary time to avoid high traffic
 
@@ -14,9 +23,14 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ github.token }}
+      UPDATE_MODE: ${{ inputs.update_mode || 'tag' }}
     outputs:
-      has_updates: ${{steps.remote_release.outputs.VERSION != steps.local_release.outputs.VERSION}}
+      has_updates: ${{ steps.remote_release.outputs.VERSION != steps.local_release.outputs.VERSION }}
+      update_mode: ${{ steps.mode.outputs.UPDATE_MODE }}
     steps:
+    - name: Determine update mode
+      id: mode
+      run: echo "UPDATE_MODE=$UPDATE_MODE" >> "$GITHUB_OUTPUT"
     - name: Checkout repository
       uses: actions/checkout@v4
       with:
@@ -24,17 +38,29 @@ jobs:
     - name: What's the latest graypaper-archive version?
       id: remote_release
       run: |
-        REMOTE_TAG=$(set -eo pipefail && gh api /repos/FluffyLabs/graypaper-archive/releases/latest | jq -r '.tag_name')
-        echo "VERSION=$REMOTE_TAG" >> "$GITHUB_OUTPUT"
-        echo "The remote version is $REMOTE_TAG"
+        if [ "$UPDATE_MODE" = "nightly" ]; then
+          REMOTE_SHA=$(gh api /repos/FluffyLabs/graypaper-archive/commits/main --jq '.sha')
+          echo "VERSION=$REMOTE_SHA" >> "$GITHUB_OUTPUT"
+          echo "The remote main SHA is $REMOTE_SHA"
+        else
+          REMOTE_TAG=$(set -eo pipefail && gh api /repos/FluffyLabs/graypaper-archive/releases/latest | jq -r '.tag_name')
+          echo "VERSION=$REMOTE_TAG" >> "$GITHUB_OUTPUT"
+          echo "The remote version is $REMOTE_TAG"
+        fi
     - name: What's the version we're using?
       id: local_release
       run: |
         cd graypaper-archive
         git fetch --tags
-        LOCAL_TAG=$(git describe --tags)
-        echo "VERSION=$LOCAL_TAG" >> "$GITHUB_OUTPUT"
-        echo "The local version is $LOCAL_TAG"
+        if [ "$UPDATE_MODE" = "nightly" ]; then
+          LOCAL_SHA=$(git rev-parse HEAD)
+          echo "VERSION=$LOCAL_SHA" >> "$GITHUB_OUTPUT"
+          echo "The local SHA is $LOCAL_SHA"
+        else
+          LOCAL_TAG=$(git describe --tags)
+          echo "VERSION=$LOCAL_TAG" >> "$GITHUB_OUTPUT"
+          echo "The local version is $LOCAL_TAG"
+        fi
   update:
     name: Update
     runs-on: ubuntu-latest
@@ -44,6 +70,7 @@ jobs:
       pull-requests: write
     env:
       GH_TOKEN: ${{ github.token }}
+      UPDATE_MODE: ${{ needs.check_for_updates.outputs.update_mode }}
     if: needs.check_for_updates.outputs.has_updates == 'true'
     steps:
       - name: Checkout repository
@@ -54,10 +81,17 @@ jobs:
         id: archive_update
         run: |
           cd graypaper-archive
-          git fetch --tags
-          LATEST_TAG=$(git describe --tags $(git rev-list --tags --max-count=1))
-          git checkout $LATEST_TAG
-          echo "VERSION=$LATEST_TAG" >> "$GITHUB_OUTPUT"
+          if [ "$UPDATE_MODE" = "nightly" ]; then
+            git fetch origin main
+            git checkout origin/main
+            SHORT_SHA=$(git rev-parse --short HEAD)
+            echo "VERSION=nightly-$SHORT_SHA" >> "$GITHUB_OUTPUT"
+          else
+            git fetch --tags
+            LATEST_TAG=$(git describe --tags $(git rev-list --tags --max-count=1))
+            git checkout $LATEST_TAG
+            echo "VERSION=$LATEST_TAG" >> "$GITHUB_OUTPUT"
+          fi
           echo "TAG_NAME=$(date +\"%Y-%m-%d\")" >> "$GITHUB_OUTPUT"
           cd ..
       - name: Use git as github actions bot
@@ -77,6 +111,7 @@ jobs:
             --title "Bump Graypaper to ${{steps.archive_update.outputs.VERSION}}" --body ""
           gh pr merge --rebase --delete-branch
       - name: Create Release
+        if: env.UPDATE_MODE != 'nightly'
         run: |
           gh release create --draft ${{ steps.archive_update.outputs.TAG_NAME }} \
             -t "Release ${{ steps.archive_update.outputs.TAG_NAME }}" \


### PR DESCRIPTION
## Summary
- Add a `workflow_dispatch` input to select between `tag` (latest release) and `nightly` (latest main branch) update modes
- Nightly mode compares and checks out the graypaper-archive `main` branch SHA instead of release tags
- Skip GitHub release creation for nightly updates

## Test plan
- [ ] Trigger workflow manually with `tag` mode and verify it behaves as before
- [ ] Trigger workflow manually with `nightly` mode and verify it tracks the main branch SHA
- [ ] Verify scheduled runs default to `tag` mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added manual workflow dispatch with configurable update mode selection (`tag` or `nightly`).
  * Introduced nightly build mode alongside standard tagged release updates.
  * Implemented mode-specific update detection and versioning logic for flexible deployment strategies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->