### PR TITLE
fix: use hash instead of nightly alias in asset URLs

### DIFF
--- a/src/components/MetadataProvider/MetadataProvider.tsx
+++ b/src/components/MetadataProvider/MetadataProvider.tsx
@@ -61,14 +61,12 @@ export function MetadataProvider({ children }: IMetadataProviderProps) {
   const context = useMemo<IMetadataContext | null>(() => {
     if (!metadata) return null;
 
-    const resolveVersion = (version: string) => (version === metadata.nightly?.hash ? "nightly" : version);
-
     return {
       metadata,
       urlGetters: {
-        pdf: (version) => `${METADATA_HOST}/graypaper-${resolveVersion(version)}.pdf`,
-        synctex: (version) => `${METADATA_HOST}/graypaper-${resolveVersion(version)}.synctex.json`,
-        texDirectory: (version) => `${METADATA_HOST}/tex-${resolveVersion(version)}`,
+        pdf: (version) => `${METADATA_HOST}/graypaper-${version}.pdf`,
+        synctex: (version) => `${METADATA_HOST}/graypaper-${version}.synctex.json`,
+        texDirectory: (version) => `${METADATA_HOST}/tex-${version}`,
         legacyReaderRedirect: (hash) => `${LEGACY_READER_HOST}/${hash}`,
       },
     };


### PR DESCRIPTION
## Summary
- Remove `resolveVersion` helper that mapped nightly commit hashes to the string `"nightly"` in asset URLs
- Nightly builds now use their commit hash in PDF, synctex, and tex directory URLs, consistent with all other versions

## Test plan
- [ ] Verify nightly PDF loads correctly using the hash-based URL
- [ ] Verify synctex and tex directory URLs resolve for nightly versions
- [ ] Confirm non-nightly versions are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal version handling logic for improved code maintainability. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->