### PR TITLE
chore(deps): bump dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "pdfjs-dist": "^6.0.227",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
-        "react-tooltip": "^6.0.6",
+        "react-tooltip": "^6.0.8",
         "tailwind-merge": "^3.5.0"
       },
       "devDependencies": {
@@ -6474,9 +6474,9 @@
       }
     },
     "node_modules/react-tooltip": {
-      "version": "6.0.6",
-      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-6.0.6.tgz",
-      "integrity": "sha512-lVTkfNeswvos9VUdV0McdsnVYczxWQXFG2I15sHvXHEmudYXCSwHKrsbJH1j+WmawrB+83tS28vJYSz5m/Fa7g==",
+      "version": "6.0.8",
+      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-6.0.8.tgz",
+      "integrity": "sha512-VPjtBPyoFwq72QVE6GYB/LtfEg/mnFBHqL0nD0oNNmjH8EZYFyBwgnFKNCOp5zCte45k1weXjKc0wXE6NICpfg==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/dom": "1.7.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "2.4.13",
-        "@commitlint/cli": "^21.0.0",
+        "@commitlint/cli": "^21.0.2",
         "@commitlint/config-conventional": "^21.0.0",
         "@tailwindcss/postcss": "^4.2.3",
         "@tailwindcss/vite": "^4.2.4",
@@ -332,17 +332,17 @@
       }
     },
     "node_modules/@commitlint/cli": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-21.0.0.tgz",
-      "integrity": "sha512-p3y2oC0G2R45zaadMwBxCiSesS8digi5RDplP3Zrfpzm7xIgrgAj0W4fGzONjpHyg8obDVJDU45g5txzeMcblg==",
+      "version": "21.0.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-21.0.2.tgz",
+      "integrity": "sha512-YMmfLbqBg+ZRvvmPhc+cilSQFrh/AgzVgCT1U/OifmUZEwPbvCtA8rN//YNaF9d5eoZphxVMGYtmwA2QgQORgg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/format": "^21.0.0",
-        "@commitlint/lint": "^21.0.0",
-        "@commitlint/load": "^21.0.0",
-        "@commitlint/read": "^21.0.0",
-        "@commitlint/types": "^21.0.0",
+        "@commitlint/format": "^21.0.1",
+        "@commitlint/lint": "^21.0.2",
+        "@commitlint/load": "^21.0.2",
+        "@commitlint/read": "^21.0.2",
+        "@commitlint/types": "^21.0.1",
         "tinyexec": "^1.0.0",
         "yargs": "^18.0.0"
       },
@@ -354,9 +354,9 @@
       }
     },
     "node_modules/@commitlint/cli/node_modules/@commitlint/types": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-21.0.0.tgz",
-      "integrity": "sha512-6nEz+M7I90iix4sviA8NLwskOuyt0M98KUU2aYgiKbn46jMSxUm1l2ACtzRd9ec+y38aKyJhW4Fp6NW0z35kJQ==",
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-21.0.1.tgz",
+      "integrity": "sha512-4u7w8jcoCUFWhjWnASYzZHAP34OqOtuFBN87nQmFvqda03YU0T6z+yB4w0gSAMpekiRqqGk5rt+qSlW+a2vSEg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -396,13 +396,13 @@
       }
     },
     "node_modules/@commitlint/config-validator": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-21.0.0.tgz",
-      "integrity": "sha512-v0UplTYryNUB463X5WrelzKq5/qyYm9/iUNk38S7ZLnd56Uuk2T9awhYKGlgD2/4L5YuN2gsKkyy4EHpRPPz2Q==",
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-21.0.1.tgz",
+      "integrity": "sha512-Zd2UFdndeMMaW2O96HK0tdfT4gOImUvidMpAd/pws2zZ4m1nrAZ/9b/v2JYuE8fs86GpXv9F7LNaIuCIWhY+pA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/types": "^21.0.0",
+        "@commitlint/types": "^21.0.1",
         "ajv": "^8.11.0"
       },
       "engines": {
@@ -410,9 +410,9 @@
       }
     },
     "node_modules/@commitlint/config-validator/node_modules/@commitlint/types": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-21.0.0.tgz",
-      "integrity": "sha512-6nEz+M7I90iix4sviA8NLwskOuyt0M98KUU2aYgiKbn46jMSxUm1l2ACtzRd9ec+y38aKyJhW4Fp6NW0z35kJQ==",
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-21.0.1.tgz",
+      "integrity": "sha512-4u7w8jcoCUFWhjWnASYzZHAP34OqOtuFBN87nQmFvqda03YU0T6z+yB4w0gSAMpekiRqqGk5rt+qSlW+a2vSEg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -424,13 +424,13 @@
       }
     },
     "node_modules/@commitlint/ensure": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-21.0.0.tgz",
-      "integrity": "sha512-n+OYs0Ws9GKC2WlmAeLNoPz9CUg6n/ZyYMkFF8rJ0aMn2kDTDTG0VqK/2Dco0EB4fhuF3JPIllJmU9/LKTl4aw==",
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-21.0.1.tgz",
+      "integrity": "sha512-jJ1037967wU7YN/xkv+iRlOBlmaOXPhPO5KQSqya6GyXzBlwuLzELBFao16DVg9dZyqmNrhewzwZ3SAibetHBQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/types": "^21.0.0",
+        "@commitlint/types": "^21.0.1",
         "es-toolkit": "^1.46.0"
       },
       "engines": {
@@ -438,9 +438,9 @@
       }
     },
     "node_modules/@commitlint/ensure/node_modules/@commitlint/types": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-21.0.0.tgz",
-      "integrity": "sha512-6nEz+M7I90iix4sviA8NLwskOuyt0M98KUU2aYgiKbn46jMSxUm1l2ACtzRd9ec+y38aKyJhW4Fp6NW0z35kJQ==",
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-21.0.1.tgz",
+      "integrity": "sha512-4u7w8jcoCUFWhjWnASYzZHAP34OqOtuFBN87nQmFvqda03YU0T6z+yB4w0gSAMpekiRqqGk5rt+qSlW+a2vSEg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -452,9 +452,9 @@
       }
     },
     "node_modules/@commitlint/execute-rule": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-21.0.0.tgz",
-      "integrity": "sha512-3OhTq2gQX1tEheMsbDNqxfcNHsAM6g9cub9plf05I9jCxtbNfn8Y+mhClKyUwhX4dbtmC4OLZ9i+HNmoL1aksA==",
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-21.0.1.tgz",
+      "integrity": "sha512-RifH+FmImozKBE6mozhF4K3r2RRKP7SMi/Q/zLCmExtp5e05lhHOUYqGBlFBAGNHaZxU/WYw1XuugYK9jQzqnA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -462,13 +462,13 @@
       }
     },
     "node_modules/@commitlint/format": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-21.0.0.tgz",
-      "integrity": "sha512-RTfGSrueEgofs1piqwi42U05d85wfxiMH2ncMCZnltx1XqPR3N2S48oACBtTy4xRAhWlf5XlHkK2RaDzEQu3dA==",
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-21.0.1.tgz",
+      "integrity": "sha512-ksmG2+cHGtuDPQQbhBbC4unwm444+6TiPw0d1bKf67hntgZqZ8E0g1MuYKUuyT5IH4IMmXZhKq22/Z3jBvtQIw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/types": "^21.0.0",
+        "@commitlint/types": "^21.0.1",
         "picocolors": "^1.1.1"
       },
       "engines": {
@@ -476,9 +476,9 @@
       }
     },
     "node_modules/@commitlint/format/node_modules/@commitlint/types": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-21.0.0.tgz",
-      "integrity": "sha512-6nEz+M7I90iix4sviA8NLwskOuyt0M98KUU2aYgiKbn46jMSxUm1l2ACtzRd9ec+y38aKyJhW4Fp6NW0z35kJQ==",
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-21.0.1.tgz",
+      "integrity": "sha512-4u7w8jcoCUFWhjWnASYzZHAP34OqOtuFBN87nQmFvqda03YU0T6z+yB4w0gSAMpekiRqqGk5rt+qSlW+a2vSEg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -490,13 +490,13 @@
       }
     },
     "node_modules/@commitlint/is-ignored": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-21.0.0.tgz",
-      "integrity": "sha512-K3SaaOTVY9VKhge7vl0R3ng7GENRzJQ9MPV43Tu53kAwEgSx/E0HF4US3AcVqdvlvsDUbF2yXvED95dhela83w==",
+      "version": "21.0.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-21.0.2.tgz",
+      "integrity": "sha512-H5z4t8PC9tUsmZ/o+EptM3Nq8sTFtskAShdcqxCoyzklW5eaVT5xbrDAET2uypzir9Vsj4ZZmBtyKjYe2XqgeQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/types": "^21.0.0",
+        "@commitlint/types": "^21.0.1",
         "semver": "^7.6.0"
       },
       "engines": {
@@ -504,9 +504,9 @@
       }
     },
     "node_modules/@commitlint/is-ignored/node_modules/@commitlint/types": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-21.0.0.tgz",
-      "integrity": "sha512-6nEz+M7I90iix4sviA8NLwskOuyt0M98KUU2aYgiKbn46jMSxUm1l2ACtzRd9ec+y38aKyJhW4Fp6NW0z35kJQ==",
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-21.0.1.tgz",
+      "integrity": "sha512-4u7w8jcoCUFWhjWnASYzZHAP34OqOtuFBN87nQmFvqda03YU0T6z+yB4w0gSAMpekiRqqGk5rt+qSlW+a2vSEg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -518,25 +518,25 @@
       }
     },
     "node_modules/@commitlint/lint": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-21.0.0.tgz",
-      "integrity": "sha512-dlUJA0Ka14R1YaR46JVRWE3m/8dOQAgE/D0heUfzYua5Jogtq/zzu2ITAIaB/u25DaKjtEO6kuvASzsFDyrPMw==",
+      "version": "21.0.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-21.0.2.tgz",
+      "integrity": "sha512-PnUmLYGeGLfW8oVatR9KpNxSHYAnJOEWlMZzfdeFOUq6WUrFx1fGQaWCWJqMoIll/xPM+GdfJV+tKHZVHhl0Fg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/is-ignored": "^21.0.0",
-        "@commitlint/parse": "^21.0.0",
-        "@commitlint/rules": "^21.0.0",
-        "@commitlint/types": "^21.0.0"
+        "@commitlint/is-ignored": "^21.0.2",
+        "@commitlint/parse": "^21.0.2",
+        "@commitlint/rules": "^21.0.2",
+        "@commitlint/types": "^21.0.1"
       },
       "engines": {
         "node": ">=22.12.0"
       }
     },
     "node_modules/@commitlint/lint/node_modules/@commitlint/types": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-21.0.0.tgz",
-      "integrity": "sha512-6nEz+M7I90iix4sviA8NLwskOuyt0M98KUU2aYgiKbn46jMSxUm1l2ACtzRd9ec+y38aKyJhW4Fp6NW0z35kJQ==",
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-21.0.1.tgz",
+      "integrity": "sha512-4u7w8jcoCUFWhjWnASYzZHAP34OqOtuFBN87nQmFvqda03YU0T6z+yB4w0gSAMpekiRqqGk5rt+qSlW+a2vSEg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -548,16 +548,16 @@
       }
     },
     "node_modules/@commitlint/load": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-21.0.0.tgz",
-      "integrity": "sha512-l0nBfO/20PKcJXHZqDIgh7kw/TWVVwn8zZJOkVGBK/ig/h328jBu9jK7OiDl2oZr5mLphmKGjYDR2ffEyb2lIA==",
+      "version": "21.0.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-21.0.2.tgz",
+      "integrity": "sha512-lwUE70hN0/qE/ZRROhbaX65ly/FF12DrqfReLCESo37M0OQCFAf2jRS+2tSCSORq+bm4Kdju7qNDj46uc1QzTA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/config-validator": "^21.0.0",
-        "@commitlint/execute-rule": "^21.0.0",
-        "@commitlint/resolve-extends": "^21.0.0",
-        "@commitlint/types": "^21.0.0",
+        "@commitlint/config-validator": "^21.0.1",
+        "@commitlint/execute-rule": "^21.0.1",
+        "@commitlint/resolve-extends": "^21.0.1",
+        "@commitlint/types": "^21.0.1",
         "cosmiconfig": "^9.0.1",
         "cosmiconfig-typescript-loader": "^6.1.0",
         "es-toolkit": "^1.46.0",
@@ -569,9 +569,9 @@
       }
     },
     "node_modules/@commitlint/load/node_modules/@commitlint/types": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-21.0.0.tgz",
-      "integrity": "sha512-6nEz+M7I90iix4sviA8NLwskOuyt0M98KUU2aYgiKbn46jMSxUm1l2ACtzRd9ec+y38aKyJhW4Fp6NW0z35kJQ==",
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-21.0.1.tgz",
+      "integrity": "sha512-4u7w8jcoCUFWhjWnASYzZHAP34OqOtuFBN87nQmFvqda03YU0T6z+yB4w0gSAMpekiRqqGk5rt+qSlW+a2vSEg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -583,9 +583,9 @@
       }
     },
     "node_modules/@commitlint/message": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-21.0.0.tgz",
-      "integrity": "sha512-+daU92JaOHhI2En9KcH+2mvZGJ6D4YSxb/32QDwqkOwSj1Vanjio8PbAqX7dneACdg6B7RgQ7i3mpyYZAws4nw==",
+      "version": "21.0.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-21.0.2.tgz",
+      "integrity": "sha512-5n4aqHGD/FNnom/D5L8i7cYtV+xjuXcBL832C3w9VglEsZzIsoHpJsvxzJ7cgiOsOdc/2jU4t5+7qMHh7GBX3g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -593,13 +593,13 @@
       }
     },
     "node_modules/@commitlint/parse": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-21.0.0.tgz",
-      "integrity": "sha512-1dbvFBcQK79aTbpc2QCrgEDc6/MMkQ0Mdz4gGmYkN4AHMnAK9HesSewTHqGTrW5mALrMlYSgcWyvKjloY2w19A==",
+      "version": "21.0.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-21.0.2.tgz",
+      "integrity": "sha512-QVZJhGHTm+oiuWyEKOCTQ0ZM3mfJ0eGWFeHuj7WzSKEth+UukcCHac9GD8pgdFlg/qGkFWOtyaNd1T8REgagaw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/types": "^21.0.0",
+        "@commitlint/types": "^21.0.1",
         "conventional-changelog-angular": "^8.2.0",
         "conventional-commits-parser": "^6.3.0"
       },
@@ -608,9 +608,9 @@
       }
     },
     "node_modules/@commitlint/parse/node_modules/@commitlint/types": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-21.0.0.tgz",
-      "integrity": "sha512-6nEz+M7I90iix4sviA8NLwskOuyt0M98KUU2aYgiKbn46jMSxUm1l2ACtzRd9ec+y38aKyJhW4Fp6NW0z35kJQ==",
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-21.0.1.tgz",
+      "integrity": "sha512-4u7w8jcoCUFWhjWnASYzZHAP34OqOtuFBN87nQmFvqda03YU0T6z+yB4w0gSAMpekiRqqGk5rt+qSlW+a2vSEg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -622,14 +622,14 @@
       }
     },
     "node_modules/@commitlint/read": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-21.0.0.tgz",
-      "integrity": "sha512-8VKLKLl2vBSKoTMm1LwcySsyxrBeotnqcT5qJi9pPuPfqSapdAD870Ckgh79c41UFywL6kMqtiyY+kxtfcqZGg==",
+      "version": "21.0.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-21.0.2.tgz",
+      "integrity": "sha512-BtsrnLVycSSKf4Q0gMch4giCj5NNlmcbhc8ra5vONgGtP2IjRDo33bEFtr5Pm+2N+5fXGWb2MksWPrspPfdhdw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/top-level": "^21.0.0",
-        "@commitlint/types": "^21.0.0",
+        "@commitlint/top-level": "^21.0.2",
+        "@commitlint/types": "^21.0.1",
         "git-raw-commits": "^5.0.0",
         "tinyexec": "^1.0.0"
       },
@@ -638,9 +638,9 @@
       }
     },
     "node_modules/@commitlint/read/node_modules/@commitlint/types": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-21.0.0.tgz",
-      "integrity": "sha512-6nEz+M7I90iix4sviA8NLwskOuyt0M98KUU2aYgiKbn46jMSxUm1l2ACtzRd9ec+y38aKyJhW4Fp6NW0z35kJQ==",
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-21.0.1.tgz",
+      "integrity": "sha512-4u7w8jcoCUFWhjWnASYzZHAP34OqOtuFBN87nQmFvqda03YU0T6z+yB4w0gSAMpekiRqqGk5rt+qSlW+a2vSEg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -652,14 +652,14 @@
       }
     },
     "node_modules/@commitlint/resolve-extends": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-21.0.0.tgz",
-      "integrity": "sha512-hrJYSZRpmecmSoxYrpuJ/1Q4J9JHt4AVVtr5/Ac6upLO/jJ1DnIm2AjD+38gru3KGOec4aHCVqETuWWLJhydWw==",
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-21.0.1.tgz",
+      "integrity": "sha512-0DhjYWL6uYrY16Efa032fYk3woGJDU4AGWiG1XXltT9AMUNYKyb5cIZU2ivbaMZ3+kKFqUjikD2cjh66Sbh/Sg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/config-validator": "^21.0.0",
-        "@commitlint/types": "^21.0.0",
+        "@commitlint/config-validator": "^21.0.1",
+        "@commitlint/types": "^21.0.1",
         "es-toolkit": "^1.46.0",
         "global-directory": "^5.0.0",
         "resolve-from": "^5.0.0"
@@ -669,9 +669,9 @@
       }
     },
     "node_modules/@commitlint/resolve-extends/node_modules/@commitlint/types": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-21.0.0.tgz",
-      "integrity": "sha512-6nEz+M7I90iix4sviA8NLwskOuyt0M98KUU2aYgiKbn46jMSxUm1l2ACtzRd9ec+y38aKyJhW4Fp6NW0z35kJQ==",
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-21.0.1.tgz",
+      "integrity": "sha512-4u7w8jcoCUFWhjWnASYzZHAP34OqOtuFBN87nQmFvqda03YU0T6z+yB4w0gSAMpekiRqqGk5rt+qSlW+a2vSEg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -683,25 +683,25 @@
       }
     },
     "node_modules/@commitlint/rules": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-21.0.0.tgz",
-      "integrity": "sha512-NgQhX1qENA+rbrMw5KKyvVZpZG4D/0wgK8Z4INtcwKbfKtVDFMbn0oNc/Rs8wdyBPBj7ue8Lo/GllUL2Mqjwkg==",
+      "version": "21.0.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-21.0.2.tgz",
+      "integrity": "sha512-k6tQ69Td7t2qUSIbik8D3TL1q3ZJpkEbV+yLogDzCRAdOxJm4ndhtBNREsLA1/puRfWvzS9eioF2w43WT+hHgQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/ensure": "^21.0.0",
-        "@commitlint/message": "^21.0.0",
-        "@commitlint/to-lines": "^21.0.0",
-        "@commitlint/types": "^21.0.0"
+        "@commitlint/ensure": "^21.0.1",
+        "@commitlint/message": "^21.0.2",
+        "@commitlint/to-lines": "^21.0.1",
+        "@commitlint/types": "^21.0.1"
       },
       "engines": {
         "node": ">=22.12.0"
       }
     },
     "node_modules/@commitlint/rules/node_modules/@commitlint/types": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-21.0.0.tgz",
-      "integrity": "sha512-6nEz+M7I90iix4sviA8NLwskOuyt0M98KUU2aYgiKbn46jMSxUm1l2ACtzRd9ec+y38aKyJhW4Fp6NW0z35kJQ==",
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-21.0.1.tgz",
+      "integrity": "sha512-4u7w8jcoCUFWhjWnASYzZHAP34OqOtuFBN87nQmFvqda03YU0T6z+yB4w0gSAMpekiRqqGk5rt+qSlW+a2vSEg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -713,9 +713,9 @@
       }
     },
     "node_modules/@commitlint/to-lines": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-21.0.0.tgz",
-      "integrity": "sha512-qMwvrJK/x3dPcXsIAtQAMKV5Q0wTioyqyHKR06vVN4wmBF4cCrrLq5x81FDeY3Ba+GWgDt0/P3Zw/IHGM8lwgg==",
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-21.0.1.tgz",
+      "integrity": "sha512-bd1BFII7p1EQZre9Kaj+kKaMFP3cFCdt21K7DItVux9XP5WjLgJ0/Uy1pJJh9aPwVJ6SKg62PxqlZaHI8hQAXw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -723,9 +723,9 @@
       }
     },
     "node_modules/@commitlint/top-level": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-21.0.0.tgz",
-      "integrity": "sha512-8jPqyWZueuN4hU6/ArKVsZ6i8xWtjIrbzHEOaLaTGUfjhhbZNBfXef/DGjzxy55hAv3yFNxHLINfI1bCJ0/MzA==",
+      "version": "21.0.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-21.0.2.tgz",
+      "integrity": "sha512-s9KKM+e+mXgFeIh4n7KmOGAVT3mkJ3Fp1bBYHIK5pjeUwlEMzp/tZfb5u0Poa680AsQTXMEMRxZi1vQ9m2X5ug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "@vitejs/plugin-react": "^6.0.1",
         "husky": "^9.1.7",
         "jsdom": "^29.1.1",
-        "tailwindcss": "^4.3.0",
+        "tailwindcss": "^4.3.1",
         "typescript": "^6.0.2",
         "vite": "^8.0.16",
         "vite-plugin-prefetch-chunk": "^0.1.2",
@@ -6791,9 +6791,9 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.0.tgz",
-      "integrity": "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.1.tgz",
+      "integrity": "sha512-hk+TB1m+K8CYNrP6rjQaq/Y+4Zylwpa87mLYBKCunwnnQ9p+fHb7kmSfGqyEJoxF/O6CDyABWVFEafNSYKll+Q==",
       "dev": true,
       "license": "MIT"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -3960,12 +3960,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.6.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.0.tgz",
+      "integrity": "sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.19.0"
+        "undici-types": "~8.3.0"
       }
     },
     "node_modules/@types/pako": {
@@ -7053,9 +7053,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.19.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "license": "MIT"
     },
     "node_modules/unhomoglyph": {
@@ -7498,7 +7498,7 @@
       "devDependencies": {
         "@biomejs/biome": "^2.4.13",
         "@tsconfig/node20": "^20.1.9",
-        "@types/node": "^25.5.2"
+        "@types/node": "^26.0.0"
       }
     },
     "tools/links-check": {
@@ -7517,7 +7517,7 @@
       "devDependencies": {
         "@biomejs/biome": "^2.4.13",
         "@tsconfig/node20": "^20.1.9",
-        "@types/node": "^25.5.2",
+        "@types/node": "^26.0.0",
         "ts-node": "^10.9.2",
         "typescript": "^6.0.2"
       }
@@ -7544,7 +7544,7 @@
       "devDependencies": {
         "@biomejs/biome": "^2.4.13",
         "@tsconfig/node20": "^20.1.9",
-        "@types/node": "^25.5.2",
+        "@types/node": "^26.0.0",
         "typescript": "^6.0.2"
       }
     },
@@ -7553,7 +7553,7 @@
       "license": "ISC",
       "devDependencies": {
         "@playwright/test": "^1.58.2",
-        "@types/node": "^25.5.2"
+        "@types/node": "^26.0.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.13",
-    "@commitlint/cli": "^21.0.0",
+    "@commitlint/cli": "^21.0.2",
     "@commitlint/config-conventional": "^21.0.0",
     "@tailwindcss/postcss": "^4.2.3",
     "@tailwindcss/vite": "^4.2.4",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@vitejs/plugin-react": "^6.0.1",
     "husky": "^9.1.7",
     "jsdom": "^29.1.1",
-    "tailwindcss": "^4.3.0",
+    "tailwindcss": "^4.3.1",
     "typescript": "^6.0.2",
     "vite": "^8.0.16",
     "vite-plugin-prefetch-chunk": "^0.1.2",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "pdfjs-dist": "^6.0.227",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
-    "react-tooltip": "^6.0.6",
+    "react-tooltip": "^6.0.8",
     "tailwind-merge": "^3.5.0"
   },
   "devDependencies": {

--- a/shared/links-metadata/package.json
+++ b/shared/links-metadata/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@biomejs/biome": "^2.4.13",
     "@tsconfig/node20": "^20.1.9",
-    "@types/node": "^25.5.2"
+    "@types/node": "^26.0.0"
   },
   "dependencies": {
     "fastest-levenshtein": "^1.0.16"

--- a/tools/links-check/package.json
+++ b/tools/links-check/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "@biomejs/biome": "^2.4.13",
     "@tsconfig/node20": "^20.1.9",
-    "@types/node": "^25.5.2",
+    "@types/node": "^26.0.0",
     "ts-node": "^10.9.2",
     "typescript": "^6.0.2"
   },

--- a/tools/matrix-bot/package.json
+++ b/tools/matrix-bot/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@biomejs/biome": "^2.4.13",
     "@tsconfig/node20": "^20.1.9",
-    "@types/node": "^25.5.2",
+    "@types/node": "^26.0.0",
     "typescript": "^6.0.2"
   },
   "dependencies": {

--- a/tools/snapshot-tests/package.json
+++ b/tools/snapshot-tests/package.json
@@ -15,6 +15,6 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.58.2",
-    "@types/node": "^25.5.2"
+    "@types/node": "^26.0.0"
   }
 }


### PR DESCRIPTION
Combines open Dependabot PRs into a single bump. All changes verified locally with `npm run qa` (biome ci), `tsc -b`, and `vitest` (100 tests passing).

## Included (npm)
- bumps `@commitlint/cli` from 21.0.0 to 21.0.2 (#451)
- bumps `@types/node` from 25.6.0 to 26.0.0 (#452) — ⚠️ **major version bump**; applies to workspace packages (`tools/*`, `shared/links-metadata`). The original PR's CI passed and local typecheck/tests are green, so it is included.
- bumps `react-tooltip` from 6.0.6 to 6.0.8 (#453)
- bumps `tailwindcss` from 4.3.0 to 4.3.1 (#454)

## Excluded
- **`@biomejs/biome` 2.4.13 → 2.5.0 (#450)** — left open. Biome 2.5.0 enables a stricter `lint/a11y/useKeyWithClickEvents` rule that flags **7 pre-existing errors** (e.g. `src/components/Search/Search.tsx:281`, `<a onClick>` without a keyboard handler), causing `npm run qa` to fail. Upgrading requires either adding keyboard handlers to those elements or configuring the rule — a behavioral change that should be reviewed separately rather than bundled into a routine dependency bump.

Closes #451, #452, #453, #454. #450 remains open pending the lint fixes above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development dependencies to their latest compatible versions across the project for improved stability and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->